### PR TITLE
Fix `notify` actions.

### DIFF
--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -10,6 +10,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart zookeeper
 
 - name: Setup zookeeper zoo.cfg
   template:
@@ -18,6 +20,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart zookeeper
 
 - name: Setup quorum for mesos-master
   template:
@@ -26,6 +30,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart mesos-master
 
 - name: Setup ip for mesos-master
   template:
@@ -34,6 +40,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart mesos-master
 
 - name: Setup hostname for mesos-master
   template:
@@ -42,17 +50,25 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart mesos-master
 
 - name: Create directory for marathon configuration
   file:
     path: /etc/marathon/conf
     state: directory
+  notify:
+    - restart marathon
 
 - name: Copy mesos-master hostnames to marathon configuration
   command: cp /etc/mesos-master/hostname /etc/marathon/conf/
+  notify:
+    - restart marathon
 
 - name: Copy mesos-master zookeeper addresses to marathon
   command: cp /etc/mesos/zk /etc/marathon/conf/master
+  notify:
+    - restart marathon
 
 - name: Setup zookeeper addresses on marathon
   template:
@@ -61,6 +77,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart marathon
 
 - name: Increase marathon executor timeout
   template:
@@ -70,6 +88,4 @@
     group=root
     mode=0644
   notify:
-    - restart zookeeper
-    - restart mesos-master
     - restart marathon

--- a/roles/slave/handlers/main.yml
+++ b/roles/slave/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 # handlers file for slave
+
 - name: restart mesos-slave
   service:
     name: mesos-slave

--- a/roles/slave/tasks/main.yml
+++ b/roles/slave/tasks/main.yml
@@ -25,6 +25,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart mesos-slave
 
 - name: Setup hostname for mesos-slave
   template:
@@ -33,6 +35,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart mesos-slave
 
 - name: Enable docker containerizer
   template:
@@ -41,6 +45,8 @@
     owner=root
     group=root
     mode=0644
+  notify:
+    - restart mesos-slave
 
 - name: Increase mesos-slave executor timeout (delay when pulling docker slave)
   template:
@@ -49,4 +55,5 @@
     owner=root
     group=root
     mode=0644
-  notify: restart mesos-slave
+  notify:
+    - restart mesos-slave


### PR DESCRIPTION
- `notify` actions are only triggered if tasks has `changed` status.
- We need to make sure that when a task gets changed the appropriate
  service gets restarted.
- Make notifications specific to each task.
